### PR TITLE
업로드 전 계약서 고유 번호 반환 API 개발 

### DIFF
--- a/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
+++ b/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
@@ -4,14 +4,13 @@ import com.partner.contract.agreement.dto.AgreementListResponseDto;
 import com.partner.contract.agreement.service.AgreementService;
 import com.partner.contract.global.exception.dto.SuccessResponse;
 import com.partner.contract.global.exception.error.SuccessCode;
+import com.partner.contract.standard.dto.FileUploadInitRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
+import java.util.Map;
 
 @RequiredArgsConstructor
 @RestController
@@ -38,5 +37,11 @@ public class AgreementController {
         List<AgreementListResponseDto> agreements = agreementService.findAgreementListByCategoryId(categoryId);
 
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SELECT_SUCCESS.getCode(), SuccessCode.SELECT_SUCCESS.getMessage(), agreements));
+    }
+
+    @PostMapping("/upload/init")
+    public ResponseEntity<SuccessResponse<Map<String, Long>>> agreementFileUploadInit(@RequestBody FileUploadInitRequestDto requestDto) {
+        Long id = agreementService.initFileUpload(requestDto);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), Map.of("id", id)));
     }
 }

--- a/src/main/java/com/partner/contract/agreement/domain/Agreement.java
+++ b/src/main/java/com/partner/contract/agreement/domain/Agreement.java
@@ -8,6 +8,8 @@ import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 import java.time.LocalDateTime;
 import java.util.List;
@@ -15,6 +17,7 @@ import java.util.List;
 @Entity
 @NoArgsConstructor
 @Getter
+@EntityListeners(AuditingEntityListener.class)
 public class Agreement {
 
     @Id
@@ -28,24 +31,20 @@ public class Agreement {
     @Enumerated(EnumType.STRING)
     private FileType type;
 
-    @Column(nullable = false)
     private String url;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private FileStatus fileStatus;
 
-    @Column(nullable = false)
     @Enumerated(EnumType.STRING)
     private AiStatus aiStatus;
 
+    @CreatedDate
     @Column(nullable = false)
     private LocalDateTime createdAt;
 
-    @Column(nullable = false)
     private String summaryContent;
 
-    @Column(nullable = false)
     private Integer totalPage;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/partner/contract/agreement/dto/FileUploadInitRequestDto.java
+++ b/src/main/java/com/partner/contract/agreement/dto/FileUploadInitRequestDto.java
@@ -1,0 +1,11 @@
+package com.partner.contract.agreement.dto;
+
+import com.partner.contract.common.enums.FileType;
+import lombok.Data;
+
+@Data
+public class FileUploadInitRequestDto {
+    private String name; // 문서 이름
+    private FileType type; // 문서 타입
+    private Long categoryId; // 카테고리 ID
+}

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -3,8 +3,12 @@ package com.partner.contract.agreement.service;
 import com.partner.contract.agreement.domain.Agreement;
 import com.partner.contract.agreement.dto.AgreementListResponseDto;
 import com.partner.contract.agreement.repository.AgreementRepository;
+import com.partner.contract.category.domain.Category;
+import com.partner.contract.category.repository.CategoryRepository;
 import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
+import com.partner.contract.standard.domain.Standard;
+import com.partner.contract.standard.dto.FileUploadInitRequestDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,6 +21,7 @@ import java.util.stream.Collectors;
 @Transactional
 public class AgreementService {
     private final AgreementRepository agreementRepository;
+    private final CategoryRepository categoryRepository;
 
     public List<AgreementListResponseDto> findAgreementList() {
         return agreementRepository.findAllByOrderByCreatedAtDesc()
@@ -41,5 +46,18 @@ public class AgreementService {
                 .stream()
                 .map(AgreementListResponseDto::fromEntity)
                 .collect(Collectors.toList());
+    }
+
+    public Long initFileUpload(FileUploadInitRequestDto requestDto) {
+        Category category = categoryRepository.findById(requestDto.getCategoryId())
+                .orElseThrow(() -> new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND_ERROR));
+
+        Agreement agreement = Agreement.builder()
+                .name(requestDto.getName())
+                .type(requestDto.getType())
+                .category(category)
+                .build();
+
+        return agreementRepository.save(agreement).getId();
     }
 }


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
feat/agreement/upload-init -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 업로드 전 계약서 고유 번호를 반환하는 API를 개발했습니다.


### 💬 공유사항
<!--- 리뷰어가 중점적으로 봐줬으면 하는 부분, 논의해야 할 부분, 예상되는 영향이 있다면 적어주세요. -->
- 잘못된 연관관계 설정으로 agreement와 standard 테이블 사이의 연관관계를 지칭하던 standard_id 칼럼을 RDS에서 삭제했습니다.


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.