### PR TITLE
계약서 업로드 취소 API 구현

### DIFF
--- a/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
+++ b/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
@@ -46,6 +46,12 @@ public class AgreementController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), Map.of("id", id)));
     }
 
+    @DeleteMapping("/upload/{id}")
+    public ResponseEntity<SuccessResponse<String>> agreementFileUploadCancel(@PathVariable("id") Long id){
+        agreementService.cancelFileUpload(id);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
+    }
+
     @PatchMapping("/upload/{id}")
     public ResponseEntity<SuccessResponse<Map<String, Long>>> standardFileUpload(
             @RequestPart("file") MultipartFile file,

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -37,7 +37,7 @@ public class AgreementService {
 
     @Value("${secret.flask.ip}")
     private String FLASK_SERVER_IP;
-  
+
     public List<AgreementListResponseDto> findAgreementList() {
         return agreementRepository.findAllWithCategoryByOrderByCreatedAtDesc()
                 .stream()
@@ -111,5 +111,14 @@ public class AgreementService {
         } else {
             throw new ApplicationException(HttpStatus.INTERNAL_SERVER_ERROR, "F-" + flaskResponseBody.getCode(), flaskResponseBody.getMessage());
         }
+    }
+
+    public void cancelFileUpload(Long id) {
+        Agreement agreement = agreementRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.AGREEMENT_NOT_FOUND_ERROR));
+
+        if (agreement.getFileStatus() != null || agreement.getAiStatus() != null) {
+            throw new ApplicationException(ErrorCode.FILE_DELETE_ERROR);
+        }
+        agreementRepository.delete(agreement);
     }
 }

--- a/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
@@ -33,6 +33,7 @@ public enum ErrorCode {
     // File
     S3_FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "S3 파일 업로드 중 에러가 발생했습니다."),
     FILE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F002", "파일 처리 중 에러가 발생했습니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "이미 S3 업로드 및 AI 분석이 진행 중인 파일입니다."),
     
     // Flask
     Flask_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F001", "Flask에서 반환된 데이터 형식이 올바르지 않습니다."),


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) feat/agreement/delete-init-file -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 계약서 파일 업로드를 취소하는 API를 구현했습니다.
- 이미 S3에 업로드 중인 경우에는 삭제할 수 없습니다.


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.