### PR TITLE
기준문서 업로드 취소 API 개발

### DIFF
--- a/src/main/java/com/partner/contract/standard/controller/StandardController.java
+++ b/src/main/java/com/partner/contract/standard/controller/StandardController.java
@@ -47,6 +47,12 @@ public class StandardController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), Map.of("id", id)));
     }
 
+    @DeleteMapping("/upload/{id}")
+    public ResponseEntity<SuccessResponse<String>> standardFileUploadCancel(@PathVariable("id") Long id){
+        standardService.cancelFileUpload(id);
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
+    }
+
     @GetMapping("/{id}")
     public ResponseEntity<SuccessResponse<StandardResponseDto>> standardById(@PathVariable("id") Long id) {
         StandardResponseDto standard = standardService.findStandardById(id);

--- a/src/main/java/com/partner/contract/standard/service/StandardService.java
+++ b/src/main/java/com/partner/contract/standard/service/StandardService.java
@@ -120,4 +120,13 @@ public class StandardService {
         standard.updateFileStatus(url, FileStatus.SUCCESS, AiStatus.ANALYZING);
         standardRepository.save(standard);
     }
+
+    public void cancelFileUpload(Long id) {
+        Standard standard = standardRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.STANDARD_NOT_FOUND_ERROR));
+
+        if (standard.getFileStatus() != null || standard.getAiStatus() != null) {
+            throw new ApplicationException(ErrorCode.FILE_DELETE_ERROR);
+        }
+        standardRepository.delete(standard);
+    }
 }


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) feat/agreement/delete-init-file -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 기준문서 파일 업로드를 취소하는 API를 구현했습니다.
- 이미 S3에 업로드 중인 경우에는 삭제할 수 없습니다.


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.