### PR TITLE
init 및 S3 upload API 하나로 합치기

### DIFF
--- a/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
+++ b/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
@@ -40,24 +40,18 @@ public class AgreementController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SELECT_SUCCESS.getCode(), SuccessCode.SELECT_SUCCESS.getMessage(), agreements));
     }
 
-    @PostMapping("/upload/init")
-    public ResponseEntity<SuccessResponse<Map<String, Long>>> agreementFileUploadInit(@RequestBody FileUploadInitRequestDto requestDto) {
-        Long id = agreementService.initFileUpload(requestDto);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), Map.of("id", id)));
-    }
-
     @DeleteMapping("/upload/{id}")
     public ResponseEntity<SuccessResponse<String>> agreementFileUploadCancel(@PathVariable("id") Long id){
         agreementService.cancelFileUpload(id);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
     }
 
-    @PatchMapping("/upload/{id}")
+    @PostMapping("/upload/{category-id}")
     public ResponseEntity<SuccessResponse<Map<String, Long>>> standardFileUpload(
             @RequestPart("file") MultipartFile file,
-            @PathVariable("id") Long id) {
+            @PathVariable("category-id") Long categoryId) {
 
-        agreementService.uploadFile(file, id);
+        Long id = agreementService.uploadFile(file, categoryId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.UPDATE_SUCCESS.getCode(),
                 SuccessCode.UPDATE_SUCCESS.getMessage(),
                 Map.of("id", id)));

--- a/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
+++ b/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
@@ -52,8 +52,8 @@ public class AgreementController {
             @PathVariable("category-id") Long categoryId) {
 
         Long id = agreementService.uploadFile(file, categoryId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.UPDATE_SUCCESS.getCode(),
-                SuccessCode.UPDATE_SUCCESS.getMessage(),
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(),
+                SuccessCode.INSERT_SUCCESS.getMessage(),
                 Map.of("id", id)));
     }
 

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -9,9 +9,11 @@ import com.partner.contract.common.dto.FileUploadInitRequestDto;
 import com.partner.contract.common.dto.FlaskResponseDto;
 import com.partner.contract.common.enums.AiStatus;
 import com.partner.contract.common.enums.FileStatus;
+import com.partner.contract.common.enums.FileType;
 import com.partner.contract.common.service.S3FileUploadService;
 import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
+import com.partner.contract.standard.domain.Standard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
@@ -63,37 +65,28 @@ public class AgreementService {
                 .map(AgreementListResponseDto::fromEntity)
                 .collect(Collectors.toList());
     }
+  
+    public Long uploadFile(MultipartFile file, Long categoryId) {
 
-    public Long initFileUpload(FileUploadInitRequestDto requestDto) {
-        Category category = categoryRepository.findById(requestDto.getCategoryId())
+        Category category = categoryRepository.findById(categoryId)
                 .orElseThrow(() -> new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND_ERROR));
 
         Agreement agreement = Agreement.builder()
-                .name(requestDto.getName())
-                .type(requestDto.getType())
+                .name(file.getOriginalFilename())
+                .type(FileType.fromContentType(file.getContentType()))
                 .category(category)
                 .build();
 
-        return agreementRepository.save(agreement).getId();
-    }
-  
-    @Transactional(propagation = Propagation.NOT_SUPPORTED) // FAIL 예외 처리를 위해 NOT_SUPPORTED로 설정
-    public void uploadFile(MultipartFile file, Long id) {
-
-        Agreement agreement = agreementRepository.findById(id)
-                .orElseThrow(() -> new ApplicationException(ErrorCode.STANDARD_NOT_FOUND_ERROR));
-
+        // s3 파일 저장
         String fileName = null;
         try {
-            fileName = s3FileUploadService.uploadFile(file);
+            fileName = s3FileUploadService.uploadFile(file, "agreements");
         } catch (ApplicationException e) {
-            agreement.updateFileStatus(null, FileStatus.FAILED, null);
-            agreementRepository.save(agreement);
             throw e; // 예외 다시 던지기
         }
         String url = "s3://" + s3FileUploadService.getBucketName() + "/" + fileName;
         agreement.updateFileStatus(url, FileStatus.SUCCESS, AiStatus.ANALYZING);
-        agreementRepository.save(agreement);
+        return agreementRepository.save(agreement).getId();
     }
 
     public void deleteAgreement(Long id) {

--- a/src/main/java/com/partner/contract/common/enums/FileType.java
+++ b/src/main/java/com/partner/contract/common/enums/FileType.java
@@ -1,5 +1,10 @@
 package com.partner.contract.common.enums;
 
+import com.partner.contract.global.exception.error.ApplicationException;
+import com.partner.contract.global.exception.error.ErrorCode;
+
+import java.util.Arrays;
+
 public enum FileType {
     PDF,
     DOCX,
@@ -8,4 +13,19 @@ public enum FileType {
     JPG,
     PNG,
     TXT
+    ;
+
+    public static FileType fromContentType(String contentType) {
+        if (contentType == null || !contentType.contains("/")) {
+            throw new ApplicationException(ErrorCode.FILE_TYPE_ERROR);
+        }
+
+        String extension = contentType.split("/")[1].toUpperCase();
+
+        try {
+            return FileType.valueOf(extension);
+        } catch (IllegalArgumentException e) {
+            throw new ApplicationException(ErrorCode.FILE_TYPE_ERROR);
+        }
+    }
 }

--- a/src/main/java/com/partner/contract/common/service/S3FileUploadService.java
+++ b/src/main/java/com/partner/contract/common/service/S3FileUploadService.java
@@ -29,9 +29,9 @@ public class S3FileUploadService {
         return bucketName;
     }
 
-    public String uploadFile(MultipartFile file) {
+    public String uploadFile(MultipartFile file, String folder) {
 
-        String fileName = UUID.randomUUID() + "_" + file.getOriginalFilename();
+        String fileName = folder + "/" + UUID.randomUUID() + "_" + file.getOriginalFilename();
 
         try (InputStream inputStream = file.getInputStream()) { // try-with-resources 사용
             PutObjectRequest putObjectRequest = PutObjectRequest.builder()

--- a/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
@@ -33,7 +33,8 @@ public enum ErrorCode {
     // File
     S3_FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI001", "S3 파일 업로드 중 에러가 발생했습니다."),
     FILE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI002", "파일 처리 중 에러가 발생했습니다."),
-    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "F003", "이미 S3 업로드 및 AI 분석이 진행 중인 파일입니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI003", "이미 S3 업로드 및 AI 분석이 진행 중인 파일입니다."),
+    FILE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "FI004", "지원하지 않는 파일 확장자이거나 파일 확장자를 가져올 수 없습니다."),
 
     // Analysis
     MISSING_FILE_FOR_ANALYSIS(HttpStatus.BAD_REQUEST, "AN001", "AI 분석을 수행하려면 파일이 필요합니다."),

--- a/src/main/java/com/partner/contract/standard/controller/StandardController.java
+++ b/src/main/java/com/partner/contract/standard/controller/StandardController.java
@@ -41,12 +41,6 @@ public class StandardController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.SELECT_SUCCESS.getCode(), SuccessCode.SELECT_SUCCESS.getMessage(), standards));
     }
 
-    @PostMapping("/upload/init")
-    public ResponseEntity<SuccessResponse<Map<String, Long>>> standardFileUploadInit(@RequestBody FileUploadInitRequestDto requestDto) {
-        Long id = standardService.initFileUpload(requestDto);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), Map.of("id", id)));
-    }
-
     @DeleteMapping("/upload/{id}")
     public ResponseEntity<SuccessResponse<String>> standardFileUploadCancel(@PathVariable("id") Long id){
         standardService.cancelFileUpload(id);
@@ -67,12 +61,12 @@ public class StandardController {
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
     }
 
-    @PatchMapping("/upload/{id}")
+    @PostMapping("/upload/{category-id}")
     public ResponseEntity<SuccessResponse<Map<String, Long>>> standardFileUpload(
             @RequestPart("file") MultipartFile file,
-            @PathVariable("id") Long id) {
+            @PathVariable("category-id") Long categoryId) {
 
-        standardService.uploadFile(file, id);
+        Long id = standardService.uploadFile(file, categoryId);
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.UPDATE_SUCCESS.getCode(),
                 SuccessCode.UPDATE_SUCCESS.getMessage(),
                 Map.of("id", id)));

--- a/src/main/java/com/partner/contract/standard/controller/StandardController.java
+++ b/src/main/java/com/partner/contract/standard/controller/StandardController.java
@@ -67,8 +67,8 @@ public class StandardController {
             @PathVariable("category-id") Long categoryId) {
 
         Long id = standardService.uploadFile(file, categoryId);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.UPDATE_SUCCESS.getCode(),
-                SuccessCode.UPDATE_SUCCESS.getMessage(),
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(),
+                SuccessCode.INSERT_SUCCESS.getMessage(),
                 Map.of("id", id)));
     }
 


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) fix/upload/integration-logic -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- init 및 S3 upload API 하나로 합쳤습니다.


### 💬 공유사항
<!--- 리뷰어가 중점적으로 봐줬으면 하는 부분, 논의해야 할 부분, 예상되는 영향이 있다면 적어주세요. -->
- 기존의 S3 업로드 API의 HTTP method를 PATCH -> POST 변경했습니다.
- path variable이 id(PK)에서 category-id 넘겨주는 걸로 변경됐습니다.
- 기존에 S3에서 기준문서와 계약서의 구분 없이 업로드 됐는데, 폴더화 하여 구분해서 저장하는 걸로 변경했습니다.

### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.