### PR TITLE
기준문서 및 계약서 업로드 취소 API 시 S3 파일과 RDB 데이터가 삭제되는 API 구현

### DIFF
--- a/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
+++ b/src/main/java/com/partner/contract/agreement/controller/AgreementController.java
@@ -41,9 +41,9 @@ public class AgreementController {
     }
 
     @DeleteMapping("/upload/{id}")
-    public ResponseEntity<SuccessResponse<String>> agreementFileUploadCancel(@PathVariable("id") Long id){
+    public ResponseEntity<SuccessResponse<Map<String, Long>>> agreementFileUploadCancel(@PathVariable("id") Long id){
         agreementService.cancelFileUpload(id);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), Map.of("id", id)));
     }
 
     @PostMapping("/upload/{category-id}")

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -5,22 +5,19 @@ import com.partner.contract.agreement.dto.AgreementListResponseDto;
 import com.partner.contract.agreement.repository.AgreementRepository;
 import com.partner.contract.category.domain.Category;
 import com.partner.contract.category.repository.CategoryRepository;
-import com.partner.contract.common.dto.FileUploadInitRequestDto;
 import com.partner.contract.common.dto.FlaskResponseDto;
 import com.partner.contract.common.enums.AiStatus;
 import com.partner.contract.common.enums.FileStatus;
 import com.partner.contract.common.enums.FileType;
-import com.partner.contract.common.service.S3FileUploadService;
+import com.partner.contract.common.service.S3Service;
 import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
-import com.partner.contract.standard.domain.Standard;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.http.HttpMethod;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
@@ -35,7 +32,7 @@ import java.util.stream.Collectors;
 public class AgreementService {
     private final AgreementRepository agreementRepository;
     private final CategoryRepository categoryRepository;
-    private final S3FileUploadService s3FileUploadService;
+    private final S3Service s3Service;
     private final RestTemplate restTemplate;
 
     @Value("${secret.flask.ip}")
@@ -80,11 +77,11 @@ public class AgreementService {
         // s3 파일 저장
         String fileName = null;
         try {
-            fileName = s3FileUploadService.uploadFile(file, "agreements");
+            fileName = s3Service.uploadFile(file, "agreements");
         } catch (ApplicationException e) {
             throw e; // 예외 다시 던지기
         }
-        String url = "s3://" + s3FileUploadService.getBucketName() + "/" + fileName;
+        String url = "s3://" + s3Service.getBucketName() + "/" + fileName;
         agreement.updateFileStatus(url, FileStatus.SUCCESS, AiStatus.ANALYZING);
         return agreementRepository.save(agreement).getId();
     }
@@ -117,9 +114,14 @@ public class AgreementService {
     public void cancelFileUpload(Long id) {
         Agreement agreement = agreementRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.AGREEMENT_NOT_FOUND_ERROR));
 
-        if (agreement.getFileStatus() != null || agreement.getAiStatus() != null) {
+        if (agreement.getFileStatus() == FileStatus.SUCCESS && agreement.getAiStatus() != AiStatus.ANALYZING){
+            // S3에 업로드 된 파일 삭제
+            s3Service.deleteFile(agreement.getUrl());
+
+            // RDB 데이터 삭제
+            agreementRepository.delete(agreement);
+        } else {
             throw new ApplicationException(ErrorCode.FILE_DELETE_ERROR);
         }
-        agreementRepository.delete(agreement);
     }
 }

--- a/src/main/java/com/partner/contract/common/service/S3Service.java
+++ b/src/main/java/com/partner/contract/common/service/S3Service.java
@@ -2,6 +2,7 @@ package com.partner.contract.common.service;
 
 import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -9,8 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
-import software.amazon.awssdk.services.s3.model.PutObjectRequest;
-import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+import software.amazon.awssdk.services.s3.model.*;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,7 +19,7 @@ import java.util.UUID;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class S3FileUploadService {
+public class S3Service {
     private final S3Client s3Client;
 
     @Value("${secret.aws.s3.bucket-name}")
@@ -52,6 +52,44 @@ public class S3FileUploadService {
             }
         } catch (IOException e) {
             throw new ApplicationException(ErrorCode.FILE_PROCESSING_ERROR);
+        } catch (S3Exception e) {
+            throw new ApplicationException(ErrorCode.S3_CONNECTION_ERROR);
+        }
+    }
+
+    public void deleteFile(String url) {
+        String filePath = url.split(getBucketName())[1].substring(1);
+        System.out.printf("filePath: %s\n", filePath);
+
+        if (!isFileExists(filePath)) {
+            throw new ApplicationException(ErrorCode.S3_FILE_NOT_FOUND_ERROR);
+        }
+
+        try {
+            DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .build();
+
+            s3Client.deleteObject(deleteObjectRequest);
+        } catch (S3Exception e) {
+            throw new ApplicationException(ErrorCode.S3_CONNECTION_ERROR);
+        }
+    }
+
+    private boolean isFileExists(String filePath) {
+        try {
+            HeadObjectRequest headObjectRequest = HeadObjectRequest.builder()
+                    .bucket(bucketName)
+                    .key(filePath)
+                    .build();
+
+            s3Client.headObject(headObjectRequest);
+            return true; // 파일이 존재함
+        } catch (NoSuchKeyException e) {
+            return false; // 파일이 존재하지 않음 (삭제 성공)
+        } catch (S3Exception e) {
+            throw new ApplicationException(ErrorCode.S3_CONNECTION_ERROR);
         }
     }
 }

--- a/src/main/java/com/partner/contract/common/service/S3Service.java
+++ b/src/main/java/com/partner/contract/common/service/S3Service.java
@@ -59,7 +59,6 @@ public class S3Service {
 
     public void deleteFile(String url) {
         String filePath = url.split(getBucketName())[1].substring(1);
-        System.out.printf("filePath: %s\n", filePath);
 
         if (!isFileExists(filePath)) {
             throw new ApplicationException(ErrorCode.S3_FILE_NOT_FOUND_ERROR);

--- a/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
+++ b/src/main/java/com/partner/contract/global/exception/error/ErrorCode.java
@@ -33,8 +33,11 @@ public enum ErrorCode {
     // File
     S3_FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI001", "S3 파일 업로드 중 에러가 발생했습니다."),
     FILE_PROCESSING_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI002", "파일 처리 중 에러가 발생했습니다."),
-    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI003", "이미 S3 업로드 및 AI 분석이 진행 중인 파일입니다."),
+    FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI003", "S3 업로드 중이거나 AI 분석이 진행 중인 파일은 삭제할 수 없습니다."),
     FILE_TYPE_ERROR(HttpStatus.BAD_REQUEST, "FI004", "지원하지 않는 파일 확장자이거나 파일 확장자를 가져올 수 없습니다."),
+    S3_FILE_DELETE_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FI005", "S3 파일 삭제 중 에러가 발생했습니다."),
+    S3_FILE_NOT_FOUND_ERROR(HttpStatus.NOT_FOUND, "FI006", "S3에 현재 URL에 대응되는 파일이 존재하지 않습니다."),
+    S3_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "S3C001", "S3 통신 중 문제가 발생했습니다."),
 
     // Analysis
     MISSING_FILE_FOR_ANALYSIS(HttpStatus.BAD_REQUEST, "AN001", "AI 분석을 수행하려면 파일이 필요합니다."),
@@ -44,6 +47,7 @@ public enum ErrorCode {
     FLASK_SERVER_CONNECTION_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FL002", "Flask API 요청 중 문제가 발생했습니다."),
     FLASK_RESPONSE_NULL_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FL003", "Flask에서 응답한 data가 null입니다."),
     FLASK_ANALYSIS_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FL004", "Flask에서 AI 분석에 실패했습니다."),
+
     ;
 
     private final HttpStatus status;

--- a/src/main/java/com/partner/contract/standard/controller/StandardController.java
+++ b/src/main/java/com/partner/contract/standard/controller/StandardController.java
@@ -42,9 +42,9 @@ public class StandardController {
     }
 
     @DeleteMapping("/upload/{id}")
-    public ResponseEntity<SuccessResponse<String>> standardFileUploadCancel(@PathVariable("id") Long id){
+    public ResponseEntity<SuccessResponse<Map<String, Long>>> standardFileUploadCancel(@PathVariable("id") Long id){
         standardService.cancelFileUpload(id);
-        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), Map.of("id", id)));
     }
 
     @GetMapping("/{id}")


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) fix/upload/delete-file -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 기존의 기준문서/계약서 삭제 API에서 S3에 있는 파일까지 지우도록 로직이 수정됐습니다.

### 💬 공유사항
<!--- 리뷰어가 중점적으로 봐줬으면 하는 부분, 논의해야 할 부분, 예상되는 영향이 있다면 적어주세요. -->
- S3에 업로드가 되지 않았거나(Not SUCCESS) AI 분석 중(ANALYZING)인 경우 삭제될 수 없습니다.
- S3에서 파일을 삭제하기 전 실제 파일이 존재하는지 확인합니다. 만약 파일이 존재하지 않는 경우 에러가 발생합니다.


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.