### PR TITLE
카테고리 수정 및 삭제 api 구현

### DIFF
--- a/src/main/java/com/partner/contract/agreement/domain/Agreement.java
+++ b/src/main/java/com/partner/contract/agreement/domain/Agreement.java
@@ -55,6 +55,9 @@ public class Agreement {
     private List<AgreementIncorrectText> agreementIncorrectTextList;
 
     @OneToMany(mappedBy = "agreement", cascade = CascadeType.ALL)
+    private List<CustomText> customTextList;
+
+    @OneToMany(mappedBy = "agreement", cascade = CascadeType.ALL)
     private List<MemberAgreement> memberAgreementList;
 
     @Builder

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -6,7 +6,6 @@ import com.partner.contract.agreement.dto.AgreementListResponseDto;
 import com.partner.contract.agreement.repository.AgreementRepository;
 import com.partner.contract.category.domain.Category;
 import com.partner.contract.category.repository.CategoryRepository;
-import com.partner.contract.common.dto.FlaskResponseDto;
 import com.partner.contract.common.enums.AiStatus;
 import com.partner.contract.common.enums.FileStatus;
 import com.partner.contract.common.enums.FileType;
@@ -16,12 +15,8 @@ import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.ParameterizedTypeReference;
-import org.springframework.http.HttpMethod;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -85,26 +80,7 @@ public class AgreementService {
     public void deleteAgreement(Long id) {
         Agreement agreement = agreementRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.AGREEMENT_NOT_FOUND_ERROR));
 
-        String flaskUrl = FLASK_SERVER_IP + "/flask/agreements/" + id;
-
-        try {
-            ResponseEntity<FlaskResponseDto<String>> response = restTemplate.exchange(
-                    flaskUrl,
-                    HttpMethod.DELETE,
-                    null,
-                    new ParameterizedTypeReference<FlaskResponseDto<String>>() {} // ✅ 제네릭 타입 유지
-            );
-
-            FlaskResponseDto<String> body = response.getBody();
-
-            if (body != null && body.getData() != null && "success".equals(body.getData())) {
-                agreementRepository.delete(agreement);
-            } else {
-                throw new ApplicationException(ErrorCode.FLASK_SERVER_ERROR, "fail");
-            }
-        } catch (RestClientException e) {
-            throw new ApplicationException(ErrorCode.FLASK_SERVER_CONNECTION_ERROR, e.getMessage());
-        }
+        agreementRepository.delete(agreement);
     }
 
     public void cancelFileUpload(Long id) {

--- a/src/main/java/com/partner/contract/category/controller/CategoryController.java
+++ b/src/main/java/com/partner/contract/category/controller/CategoryController.java
@@ -38,4 +38,18 @@ public class CategoryController {
 
         return ResponseEntity.ok(SuccessResponse.of(SuccessCode.INSERT_SUCCESS.getCode(), SuccessCode.INSERT_SUCCESS.getMessage(), null));
     }
+
+    @PatchMapping("/{id}")
+    public ResponseEntity<SuccessResponse<String>> categoryModify(@PathVariable("id") Long id, @RequestBody Category category) {
+        categoryService.modifyCategory(id, category);
+
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.UPDATE_SUCCESS.getCode(), SuccessCode.UPDATE_SUCCESS.getMessage(), null));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<SuccessResponse<String>> categoryDelete(@PathVariable("id") Long id) {
+        categoryService.deleteCategory(id);
+
+        return ResponseEntity.ok(SuccessResponse.of(SuccessCode.DELETE_SUCCESS.getCode(), SuccessCode.DELETE_SUCCESS.getMessage(), null));
+    }
 }

--- a/src/main/java/com/partner/contract/category/domain/Category.java
+++ b/src/main/java/com/partner/contract/category/domain/Category.java
@@ -33,10 +33,10 @@ public class Category {
     @LastModifiedDate
     private LocalDateTime updatedAt;
 
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "category")
     private List<Standard> standardList;
 
-    @OneToMany(mappedBy = "category", cascade = CascadeType.ALL)
+    @OneToMany(mappedBy = "category")
     private List<Agreement> agreementList;
 
     @Builder
@@ -46,5 +46,9 @@ public class Category {
         this.updatedAt = updatedAt;
         this.standardList = standardList;
         this.agreementList = agreementList;
+    }
+
+    public void update(String name) {
+        this.name = name;
     }
 }

--- a/src/main/java/com/partner/contract/category/service/CategoryService.java
+++ b/src/main/java/com/partner/contract/category/service/CategoryService.java
@@ -1,10 +1,14 @@
 package com.partner.contract.category.service;
 
+import com.partner.contract.agreement.domain.Agreement;
+import com.partner.contract.agreement.service.AgreementService;
 import com.partner.contract.category.domain.Category;
 import com.partner.contract.category.dto.CategoryListResponseDto;
 import com.partner.contract.category.repository.CategoryRepository;
 import com.partner.contract.global.exception.error.ApplicationException;
 import com.partner.contract.global.exception.error.ErrorCode;
+import com.partner.contract.standard.domain.Standard;
+import com.partner.contract.standard.service.StandardService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -16,6 +20,8 @@ import java.util.List;
 @Transactional
 public class CategoryService {
     private final CategoryRepository categoryRepository;
+    private final StandardService standardService;
+    private final AgreementService agreementService;
 
     public List<CategoryListResponseDto> findCategoryList(String name) {
         return categoryRepository.findCategoryListOrderByName(name);
@@ -35,5 +41,31 @@ public class CategoryService {
         }
 
         categoryRepository.save(category);
+    }
+
+
+    public void modifyCategory(Long id, Category category) {
+        Category existingCategory = categoryRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND_ERROR));
+
+        existingCategory.update(category.getName());
+        categoryRepository.save(existingCategory);
+    }
+
+    public void deleteCategory(Long id) {
+        Category category = categoryRepository.findById(id).orElseThrow(() -> new ApplicationException(ErrorCode.CATEGORY_NOT_FOUND_ERROR));
+
+        List<Standard> standards = category.getStandardList();
+
+        for(Standard standard : standards) {
+            standardService.deleteStandard(standard.getId());
+        }
+
+        List<Agreement> agreements = category.getAgreementList();
+
+        for(Agreement agreement : category.getAgreementList()) {
+            agreementService.deleteAgreement(agreement.getId());
+        }
+
+        categoryRepository.deleteById(id);
     }
 }


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) feat/category/update-delete -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 카테고리 수정 및 삭제 api를 구현하였습니다
- 계약서 삭제 api에서 flask 로직 제거하였습니다


### 💬 공유사항
<!--- 리뷰어가 중점적으로 봐줬으면 하는 부분, 논의해야 할 부분, 예상되는 영향이 있다면 적어주세요. -->
- 카테고리 삭제시 기준문서와 계약서 상태를 확인 후 삭제해야해서 수동 삭제되도록 변경하였습니다


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.


### 🖼️ 스크린샷 (선택)
