### PR TITLE
기준문서 및 계약서 상태체크 스케쥴러 구현

### DIFF
--- a/src/main/java/com/partner/contract/agreement/repository/AgreementRepository.java
+++ b/src/main/java/com/partner/contract/agreement/repository/AgreementRepository.java
@@ -2,11 +2,13 @@ package com.partner.contract.agreement.repository;
 
 import com.partner.contract.agreement.domain.Agreement;
 import com.partner.contract.agreement.dto.IncorrectTextResponseDto;
+import com.partner.contract.common.enums.AiStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 @Repository
@@ -22,4 +24,6 @@ public interface AgreementRepository extends JpaRepository<Agreement, Long> {
             "FROM AgreementIncorrectText ait " +
             "WHERE ait.agreement.id = :agreementId")
     List<IncorrectTextResponseDto> findIncorrectTextByAgreementId(@Param("agreementId") Long agreementId);
+
+    List<Agreement> findByAiStatusAndCreatedAtBefore(AiStatus aiStatus, LocalDateTime fiveMinutesAgo);
 }

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -22,6 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -169,5 +170,15 @@ public class AgreementService {
         }
 
         agreement.updateAiStatus(AiStatus.SUCCESS);
+    }
+
+    public void updateExpiredAnalysisStatus() {
+        LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
+        List<Agreement> agreements = agreementRepository.findByAiStatusAndCreatedAtBefore(AiStatus.ANALYZING, fiveMinutesAgo);
+
+        for(Agreement agreement : agreements) {
+            agreement.updateAiStatus(AiStatus.FAILED);
+            agreementRepository.save(agreement);
+        }
     }
 }

--- a/src/main/java/com/partner/contract/agreement/service/AgreementService.java
+++ b/src/main/java/com/partner/contract/agreement/service/AgreementService.java
@@ -178,7 +178,7 @@ public class AgreementService {
 
         for(Agreement agreement : agreements) {
             agreement.updateAiStatus(AiStatus.FAILED);
-            agreementRepository.save(agreement);
         }
+        agreementRepository.saveAll(agreements);
     }
 }

--- a/src/main/java/com/partner/contract/common/config/SchedulerConfig.java
+++ b/src/main/java/com/partner/contract/common/config/SchedulerConfig.java
@@ -1,0 +1,28 @@
+package com.partner.contract.common.config;
+
+import com.partner.contract.agreement.service.AgreementService;
+import com.partner.contract.standard.service.StandardService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+
+@Configuration
+@EnableScheduling
+@RequiredArgsConstructor
+public class SchedulerConfig {
+    private final StandardService standardService;
+    private final AgreementService agreementService;
+
+    @Value("${schedule.use}")
+    private boolean useSchedule;
+
+    @Scheduled(cron = "${schedule.cron}")
+    public void schedule() {
+        if (useSchedule) {
+            standardService.updateExpiredAnalysisStatus();
+            agreementService.updateExpiredAnalysisStatus();
+        }
+    }
+}

--- a/src/main/java/com/partner/contract/common/config/TimeZoneConfig.java
+++ b/src/main/java/com/partner/contract/common/config/TimeZoneConfig.java
@@ -1,0 +1,14 @@
+package com.partner.contract.common.config;
+
+import jakarta.annotation.PostConstruct;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.TimeZone;
+
+@Configuration
+public class TimeZoneConfig {
+    @PostConstruct
+    public void setTimeZone() {
+        TimeZone.setDefault(TimeZone.getTimeZone("Asia/Seoul"));
+    }
+}

--- a/src/main/java/com/partner/contract/standard/repository/StandardRepository.java
+++ b/src/main/java/com/partner/contract/standard/repository/StandardRepository.java
@@ -1,11 +1,13 @@
 package com.partner.contract.standard.repository;
 
+import com.partner.contract.common.enums.AiStatus;
 import com.partner.contract.standard.domain.Standard;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,5 +22,5 @@ public interface StandardRepository extends JpaRepository<Standard, Long> {
     @Query("select s from Standard s join fetch s.category c where s.id = :id")
     Optional<Standard> findWithCategoryById(@Param("id") Long id);
 
-
+    List<Standard> findByAiStatusAndCreatedAtBefore(AiStatus aiStatus, LocalDateTime fiveMinutesAgo);
 }

--- a/src/main/java/com/partner/contract/standard/service/StandardService.java
+++ b/src/main/java/com/partner/contract/standard/service/StandardService.java
@@ -218,7 +218,7 @@ public class StandardService {
 
         for(Standard standard : standards) {
             standard.updateAiStatus(AiStatus.FAILED);
-            standardRepository.save(standard);
         }
+        standardRepository.saveAll(standards);
     }
 }

--- a/src/main/java/com/partner/contract/standard/service/StandardService.java
+++ b/src/main/java/com/partner/contract/standard/service/StandardService.java
@@ -25,6 +25,7 @@ import org.springframework.web.client.RestClientException;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -209,5 +210,15 @@ public class StandardService {
         }
 
         return standard.getAiStatus() != AiStatus.ANALYZING;
+    }
+
+    public void updateExpiredAnalysisStatus() {
+        LocalDateTime fiveMinutesAgo = LocalDateTime.now().minusMinutes(5);
+        List<Standard> standards = standardRepository.findByAiStatusAndCreatedAtBefore(AiStatus.ANALYZING, fiveMinutesAgo);
+
+        for(Standard standard : standards) {
+            standard.updateAiStatus(AiStatus.FAILED);
+            standardRepository.save(standard);
+        }
     }
 }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -19,6 +19,8 @@ spring:
       hibernate:
         ddl-auto: none
       show-sql: true
+  jackson:
+    time-zone: Asia/Seoul
 
 server:
   port: 8080
@@ -30,3 +32,7 @@ management:
   endpoint:
     health:
       show-details: always
+
+schedule:
+  cron: "0 0/5 * * * *"
+  use: true


### PR DESCRIPTION
<!-- PR 머지 시 자동으로 해당 이슈를 Close하려면 "fix #이슈번호" 형식으로 입력하세요. -->
### 🌿 반영 브랜치
ex) feat/common/check-aistatus -> dev


### ✨ 주요 변경 사항
<!--- 주된 변경 사항을 리뷰어가 알 수 있게 작성해주세요 -->
- 기준문서 및 계약서 상태체크 스케쥴러를 구현하였습니다
- 타임존 설정을 추가하였습니다


### 💬 공유사항
<!--- 리뷰어가 중점적으로 봐줬으면 하는 부분, 논의해야 할 부분, 예상되는 영향이 있다면 적어주세요. -->
- 5분마다 스케쥴러가 실행됩니다
- ec2 서버에도 타임존 설정을 변경하였습니다
- 배포 후 타임존 설정이 잘 적용되는지 테스트 필요합니다


### ☑️ PR Checklist
   PR이 다음 요구 사항을 충족하는지 확인하세요.
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 작성한 코드는 실행에 문제가 되지 않음을 확인했습니다.


### 🖼️ 스크린샷 (선택)
